### PR TITLE
Make action usable for SonarQube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
 # Git public sync action
 
-This action automatically merges branches prefixed with name "dogfood/" into the "dogfood-automerge" branch or the branch specified as input.
-
-## Inputs
-
-### `target-repo`
-
-**Required** The target repository, where the public part of a private repo will be synced
-
+This action automatically syncs private repository branches with public ones.
 
 ## Example usage
 
 ```
-uses: SonarSource/gh-action_git-octopus@master
+uses: SonarSource/gh-action_public_git_sync@master
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-with:
-  target-repo: 'slang'
+  GITHUB_TARGET_REPOSITORY: slang
+  BRANCH_NAME: master
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,18 @@
 set -e
 set -o pipefail
 
-if [ "${GITHUB_REPOSITORY}" == "SonarSource/slang" ];then
+if [[ "${GITHUB_REPOSITORY}" == "SonarSource/slang" || "${GITHUB_REPOSITORY}" == "SonarSource/sonarqube" ]];then
   echo "No sync from public repository"
+  exit 0
+fi
+
+if [ -z "${GITHUB_TARGET_REPOSITORY}" ];then
+  echo "You didn't provide a target repository"
+  exit 0
+fi
+
+if [ -z "${BRANCH_NAME}" ];then
+  echo "You didn't provide a branch name"
   exit 0
 fi
 
@@ -20,7 +30,7 @@ cd repo
 ls
 echo "Starting sync"
 pwd
-../sync_public_branch.sh slang https://${GITHUB_TOKEN}@github.com/SonarSource/${GITHUB_TARGET_REPOSITORY}.git master
+../sync_public_branch.sh ${GITHUB_REPOSITORY} https://${GITHUB_TOKEN}@github.com/SonarSource/${GITHUB_TARGET_REPOSITORY}.git ${BRANCH_NAME}
 
 echo "Starting push"
-../commit_sync_public_branch.sh ${GITHUB_TARGET_REPOSITORY} master
+../commit_sync_public_branch.sh ${GITHUB_TARGET_REPOSITORY} ${BRANCH_NAME}


### PR DESCRIPTION
It's all in the name. Currently, this action is hard-coded for Slang, and for a single branch (master). We should ideally support SonarQube, _and_ multiple branches (we have master + LTS).