### PR TITLE
Use alpine/git to speed up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM alpine:latest
+FROM alpine/git:latest
 LABEL maintainer="Thomas Vérin <thomas.verin@sonarsource.com>"
-
-#install curl jq
-RUN apk add --no-cache bash git grep
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Right now, we have to build the Docker image each time, which includes installing Bash, Git, and Grep (which isn't used; we could drop it).

If we use [`alpine/git`](https://hub.docker.com/r/alpine/git/), we could use Docker's cache, and skip the installation part. We could (almost) execute it immediately: the build would only copy the `entrypoint.sh` file. This will save time and money in the long run, especially as this is used on 3 diff. workflows.